### PR TITLE
Add MCP support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN apt-get update && apt-get install -y curl build-essential && \
 # Add cargo to PATH
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# Install openmcp proxy
+# RUN curl -sSfL 'https://raw.githubusercontent.com/decentralized-mcp/proxy/refs/heads/master/install.sh' | bash
+RUN curl -LO https://github.com/decentralized-mcp/proxy/releases/latest/download/openmcp-aarch64-unknown-linux-gnu.tgz
+RUN tar zxvf openmcp-aarch64-unknown-linux-gnu.tgz
+RUN cp openmcp /usr/local/bin/
+
 # Set working directory
 WORKDIR /app
 

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -1,0 +1,27 @@
+import httpx
+import sys
+import json
+import os
+from dotenv import load_dotenv
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("Rust compiler tools")
+
+@mcp.tool()
+async def generate(description: str, requirements: str) -> str:
+    """Generate a new Rust cargo project from the description and requirements"""
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("http://host.docker.internal:8000/generate-sync", json={'description': description, 'requirements': requirements})
+        return response.text
+
+@mcp.tool()
+async def compile_and_fix(code: str) -> str:
+    """Compile a Rust cargo project and fix any compiler errors"""
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post("http://host.docker.internal:8000/compile-and-fix", json={'code': code, 'description': 'A Rust project', 'max_attempts': 3})
+        return response.text
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,44 +6,24 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - LLM_API_KEY=dummy-key
-      - LLM_API_BASE=http://host.docker.internal:8080/v1  # This accesses your host machine from Docker
-      - LLM_MODEL=Qwen2.5-Coder-3B-Instruct
-      - LLM_EMBED_MODEL=gte-Qwen2-1.5B-instruct
-      - LLM_EMBED_SIZE=1536
+      - LLM_API_KEY=${LLM_API_KEY}
+      - LLM_API_BASE=${LLM_API_BASE:-https://coder.gaia.domains/v1}
+      - LLM_MODEL=${LLM_MODEL:-Qwen2.5-Coder-32B-Instruct-Q5_K_M}
+      - LLM_EMBED_MODEL=${LLM_EMBED_MODEL:-nomic-embed}
+      - LLM_EMBED_SIZE=${LLM_EMBED_SIZE:-768}
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
-      - SKIP_VECTOR_SEARCH=true  # Add this to avoid embedding API issues
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     depends_on:
       - qdrant
 
-  # Commenting out MCP services temporarily
-  # mcp-server:
-  #   build: .
-  #   environment:
-  #     - MCP_TRANSPORT=sse
-  #     - MCP_HOST=0.0.0.0
-  #     - MCP_PORT=3001
-  #     - LLM_API_KEY=${LLM_API_KEY}
-  #     - LLM_API_BASE=${LLM_API_BASE:-https://coder.gaia.domains/v1}
-  #     - LLM_MODEL=${LLM_MODEL:-Qwen2.5-Coder-32B-Instruct-Q5_K_M}
-  #     - LLM_EMBED_MODEL=${LLM_EMBED_MODEL:-nomic-embed}
-  #     - LLM_EMBED_SIZE=${LLM_EMBED_SIZE:-768}
-  #     - QDRANT_HOST=qdrant
-  #     - QDRANT_PORT=6333
-  #   command: python -m app.mcp_server
-  #   depends_on:
-  #     - qdrant
-
-  # mcp-proxy:
-  #   image: russellluo/mcp-proxy:0.4.0
-  #   ports:
-  #     - "3000:3000"
-  #   volumes:
-  #     - ./mcp-proxy-config.json:/app/config.json
-  #   depends_on:
-  #     - mcp-server
+  mcp-server:
+    build: .
+    command: openmcp run -p 0.0.0.0:3000 -- python app/mcp_tools.py
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api
 
   qdrant:
     image: qdrant/qdrant


### PR DESCRIPTION
The MCP server is in the `app/mcp_tools.py` script. It simply converts MCP tool calls to API calls. We will probably need to make the `host.docker.internal` URL configurable so that it works outside of the Docker environment.

The MCP server is also started in Docker compose. 

NOTE: Please clean up the Python code and remove other MCP references or functions from the code. All MCP functions should just be in `app/mcp_tools.py`.